### PR TITLE
cumulative deaths from incident deaths

### DIFF
--- a/scratch/fable-submission-mockup-allmetrics.R
+++ b/scratch/fable-submission-mockup-allmetrics.R
@@ -108,8 +108,8 @@ fit.icases <- usa %>% model(arima = ARIMA(icases, stepwise=FALSE, approximation=
 ## NOTE: using the lagged cases (3 weeks) as predictor ... maybe eventually some way to combine this with ARIMA via xreg formulat (see ?ARIMA)
 fit.ideaths <- usa %>% model(linear_caselag3 = TSLM(ideaths ~ lag(icases, 3)))
 # fit.ideaths <- usa %>% model(arima = ARIMA(ideaths, stepwise=FALSE, approximation=FALSE))
-## NOTE: for now we are just getting the
-fit.cdeaths <- usa %>% model(arima = ARIMA(cdeaths, stepwise=FALSE, approximation=FALSE))
+## NOTE: for now we are just getting the cdeaths from ARIMA
+# fit.cdeaths <- usa %>% model(arima = ARIMA(cdeaths, stepwise=FALSE, approximation=FALSE))
 
 icases_forecast <- ts_forecast(fit.icases, horizon = horizon)
 


### PR DESCRIPTION
I think this fixes the issue of creating cumulative death forecasts from incident deaths, see 5786cac. 

High level:

1. Gets the yearweek of the last week of recorded data
2. Gets the first yearweek of forecasted inc deaths
3. Checks that last week of recorded data plus one week equals the first week of forecasted data. If so, proceed.
4. Capture the cumulative deaths recorded on the last week of recorded data in step 1, and hangs on to that for later.
5. Groups by each quantile (or point estimate)
6. Calculates the cumulative sum of incident deaths week over week. So 1 week ahead = 1 week ahead. 2 weeks ahead cumsum = 1+2. 3 weeks ahead = inc deaths for 1+2+3. 4th week = 1+2+3+4.
7. Adds the last week's recorded cumulative deaths from step 4 and adds to the cumsum for each week in step 6.

Ideally this should be a function call, but it's worth thinking through how to safely execute this to guard against supplying _data_ that's unrelated to the _forecast_ you're trying to produce. Turning this into a function as the code stands now would require a user input _data_ (here, the `usa` tsibble, which contains the ccases week over week), and the _forecast_ (here `icases_forecast`). You'd want some way to validate that `icases_forecast` was produced using `usa` as the input data. The `stopifnot` should catch egregious errors, but if we want to (over?)engineer this thing to guard against mis-specifying this, we might want to output a list or tie the name of the data used to create the forecast to the attributes or something of the output from your suggested `ts_fit()` function-in-development.