### PR TITLE
submission script edits

### DIFF
--- a/submission/submission.R
+++ b/submission/submission.R
@@ -79,13 +79,13 @@ if (!is_monday()) {
   warning("Forecasts should be created on Mondays.")
   submission_filename <- here::here("submission", "SigSci-TS", paste0(Sys.Date(), "-SigSci-TS.csv"))
   readr::write_csv(submission, submission_filename)
-  validation <- validate_forecast(submission_filename, install = TRUE)
-  write_lines(validation, path = here::here("submission", "SigSci-TS", paste0(Sys.Date(), "-validation.txt")))
+  validation <- validate_forecast(submission_filename, install = !interactive())
+  write_lines(validation, here::here("submission", "SigSci-TS", paste0(Sys.Date(), "-validation.txt")))
 } else {
   submission_filename <- here::here("submission", "SigSci-TS", paste0(Sys.Date(), "-SigSci-TS.csv"))
   readr::write_csv(submission, submission_filename)
-  validation <- validate_forecast(submission_filename, install = TRUE)
-  write_lines(validation, path = here::here("submission", "SigSci-TS", paste0(Sys.Date(), "-validation.txt")))
+  validation <- validate_forecast(submission_filename, install = !interactive())
+  write_lines(validation, here::here("submission", "SigSci-TS", paste0(Sys.Date(), "-validation.txt")))
 
 }
 


### PR DESCRIPTION
this PR will bring in some edits to the `submission/submission.R` script that will make it usable in the AWS pipeline as-is

i tweaked couple of the paths in the S3 bucket and made some minor changes to the bootstrap script as well.

@stephenturner when you get a chance confirm that you're good with this interactively.

of note, the script *does* generate a submission output on non-mondays

it also will save a "validation file" (captured output from validation script), forces install of py deps during validation, and will write out the `plot_forecast()` pdf to submissions

**if** interactive it will perform the "bad states" check. i kept that condition so that we can optionally exclude states from the automated pipeline *after* we review the output.