### PR TITLE
fix for dates dropping from submission

### DIFF
--- a/R/focustools.R
+++ b/R/focustools.R
@@ -54,6 +54,7 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c(".",
                                                         "0.25",
                                                         "0.75",
                                                         "yweek",
+                                                        "yweek_tmp",
                                                         "Previous",
                                                         "horizon",
                                                         ".submission_dir"))

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -59,8 +59,10 @@ get_cases <- function(source = "jhu", granularity = "national") {
         ## within each county (fips code), year, week grouping
         dplyr::group_by(fips,epiyear,epiweek) %>%
         dplyr::summarise(icases = sum(icases, na.rm = TRUE), .groups = "drop") %>%
-        dplyr::filter(epiweek != lubridate::week(Sys.Date())) %>%
-        dplyr::group_by(fips) %>%
+        ## ignore the current week because it will likely be incomplete ...
+        dplyr::mutate(yweek_tmp = paste0(epiyear, "-", epiweek)) %>%
+        dplyr::filter((yweek_tmp != paste0(lubridate::epiyear(Sys.Date()), "-", lubridate::epiweek(Sys.Date())))) %>%
+        dplyr::select(-yweek_tmp) %>%        dplyr::group_by(fips) %>%
         dplyr::arrange(fips,epiyear,epiweek) %>%
         dplyr::mutate(ccases = cumsum(icases)) %>%
         dplyr::ungroup() %>%
@@ -74,7 +76,9 @@ get_cases <- function(source = "jhu", granularity = "national") {
         ## sum up the number of deaths at that week
         dplyr::summarise(icases = sum(icases, na.rm = TRUE), .groups = "drop") %>%
         ## ignore the current week because it will likely be incomplete ...
-        dplyr::filter(epiweek != lubridate::week(Sys.Date())) %>%
+        dplyr::mutate(yweek_tmp = paste0(epiyear, "-", epiweek)) %>%
+        dplyr::filter((yweek_tmp != paste0(lubridate::epiyear(Sys.Date()), "-", lubridate::epiweek(Sys.Date())))) %>%
+        dplyr::select(-yweek_tmp) %>%
         ## now group by state
         dplyr::group_by(state) %>%
         ## arrange by state first then date (ascending)
@@ -211,7 +215,10 @@ get_deaths <- function(source = "jhu", granularity = "national") {
         ## within each county (fips code), year, week grouping
         dplyr::group_by(fips,epiyear,epiweek) %>%
         dplyr::summarise(ideaths = sum(ideaths, na.rm = TRUE), .groups = "drop") %>%
-        dplyr::filter(epiweek != lubridate::week(Sys.Date())) %>%
+        ## ignore the current week because it will likely be incomplete ...
+        dplyr::mutate(yweek_tmp = paste0(epiyear, "-", epiweek)) %>%
+        dplyr::filter((yweek_tmp != paste0(lubridate::epiyear(Sys.Date()), "-", lubridate::epiweek(Sys.Date())))) %>%
+        dplyr::select(-yweek_tmp) %>%
         dplyr::group_by(fips) %>%
         dplyr::arrange(fips,epiyear,epiweek) %>%
         dplyr::mutate(cdeaths = cumsum(ideaths)) %>%
@@ -226,7 +233,9 @@ get_deaths <- function(source = "jhu", granularity = "national") {
         ## sum up the number of deaths at that week
         dplyr::summarise(ideaths = sum(ideaths, na.rm = TRUE), .groups = "drop") %>%
         ## ignore the current week because it will likely be incomplete ...
-        dplyr::filter(epiweek != lubridate::week(Sys.Date())) %>%
+        dplyr::mutate(yweek_tmp = paste0(epiyear, "-", epiweek)) %>%
+        dplyr::filter((yweek_tmp != paste0(lubridate::epiyear(Sys.Date()), "-", lubridate::epiweek(Sys.Date())))) %>%
+        dplyr::select(-yweek_tmp) %>%
         ## now group by statee
         dplyr::group_by(state) %>%
         ## arrange by state first then date (ascending)

--- a/submission/submission.R
+++ b/submission/submission.R
@@ -8,8 +8,6 @@ suppressPackageStartupMessages(suppressWarnings(library(focustools)))
 USonly <- FALSE
 ## Set forecasting horizon in weeks
 horizon <- 4
-## Use bootstrapping?
-bootstrap <- FALSE
 
 ## Get national data
 national <- inner_join(
@@ -26,7 +24,7 @@ usafull <-
   bind_rows(national, state) %>%
   filter(location %in% c("US", stringr::str_pad(1:56, width=2, pad="0"))) %>%
   make_tsibble() %>%
-  filter(monday>"2020-03-09")
+  filter(monday>"2020-03-01")
 stopifnot(length(unique(usafull$location))==52L)
 # Clean up
 rm(national, state)
@@ -48,7 +46,7 @@ for (loc in mylocs) {
   fits.icases <-  usa %>% model(arima = ARIMA(icases~PDQ(0,0,0)+pdq(1:2,0:2,0), stepwise=FALSE, approximation=FALSE))
   arima_params_list[[loc]] <- extract_arima_params(fits.icases)
   fits.ideaths <- usa %>% model(linear_caselag3 = TSLM(ideaths ~ lag(icases, 3)))
-  forc.icases <- ts_forecast(fits.icases, outcome = "icases", horizon = horizon, bootstrap=bootstrap)
+  forc.icases <- ts_forecast(fits.icases, outcome = "icases", horizon = horizon)
   futr.icases <- ts_futurecases(usa, forc.icases, horizon = horizon)
   forc.ideaths <- ts_forecast(fits.ideaths,  outcome = "ideaths", new_data = futr.icases, bootstrap = bootstrap)
   forc.cdeaths <- ts_forecast(outcome = "cdeaths", .data = usa, inc_forecast = forc.ideaths)


### PR DESCRIPTION
the logic we had been using to retrieve data filtered out weeks that matched the current week (b/c current week reporting will be incomplete ...)

this PR will bring in a change to explicitly use current week AND current year in that filter